### PR TITLE
Add DuckDB parquet export for Strava data puller

### DIFF
--- a/strava-data-puller/README.md
+++ b/strava-data-puller/README.md
@@ -7,6 +7,7 @@ Pull your Strava data locally via the Strava API with a focus on cycling and wal
 - Fetch per-activity detail and optional time-series streams (distance, elevation, cadence, etc.).
 - Save athlete profile info and lifetime stats.
 - Output JSON for easy reuse in other tools.
+- Export Parquet files via DuckDB for analytics workflows.
 
 ## Setup
 1. Create a Strava API application: <https://www.strava.com/settings/api>.
@@ -45,17 +46,37 @@ python strava_pull.py \
 - `--include-streams`: Also fetch activity streams for detailed analysis.
 - `--per-page`: Number of activities per page (default: 200, max allowed by Strava).
 - `--max-pages`: Safety cap on pagination pages.
+- `--skip-parquet`: Skip DuckDB Parquet export (default exports Parquet files).
 
 ### Output structure
 ```
 strava-export/
   athlete.json
+  athlete.parquet
   stats.json
+  stats.parquet
   activities.json
+  activities.ndjson
+  activities.parquet
+  activity_details.ndjson
+  activity_details.parquet
   activities/
     <activity_id>.json
   streams/
     <activity_id>.json
+  activity_streams.ndjson
+  activity_streams.parquet
+
+## DuckDB Example Query
+
+Once the export completes, you can query the Parquet files using DuckDB:
+
+```sql
+SELECT name, COUNT(*) AS total_activities
+FROM read_parquet('strava-export/activities.parquet')
+GROUP BY name
+ORDER BY total_activities DESC;
+```
 ```
 
 ## Notes

--- a/strava-data-puller/requirements.txt
+++ b/strava-data-puller/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.32.3
+duckdb==1.1.3


### PR DESCRIPTION
### Motivation
- Enable analytics workflows by producing Parquet outputs from the Strava export so users can query with DuckDB.
- Produce NDJSON versions of JSON outputs to make them consumable by DuckDB's JSON reader and support incremental appends.
- Make Parquet export optional so users without DuckDB can still use the existing JSON outputs.

### Description
- Added `duckdb==1.1.3` to `strava-data-puller/requirements.txt` and imported `duckdb` in `strava_pull.py`.
- Added `write_ndjson` and `append_ndjson` helpers and write NDJSON files `activities.ndjson`, `activity_details.ndjson`, and `activity_streams.ndjson` alongside existing JSON outputs.
- Implemented `export_parquet(out_dir)` which uses `read_json_auto` to create DuckDB tables and `COPY ... TO` to write Parquet files (`activities.parquet`, `athlete.parquet`, `stats.parquet`, etc.).
- Added CLI flag `--skip-parquet` to skip DuckDB export, and updated the script to remove stale NDJSON files before running.
- Updated `strava-data-puller/README.md` with the new outputs, `--skip-parquet` option, and a sample DuckDB query.

### Testing
- No automated tests were run for these changes (the repository and this tool do not include a repo-wide test runner or tool-specific automated tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d6ae32f7c83328ec9afd7630b7eef)