### PR TITLE
feat(lastfm): staleness detection — emit error + catalog flag after 7 days with no new scrobbles

### DIFF
--- a/music-history/scripts/lastfm_ingest.py
+++ b/music-history/scripts/lastfm_ingest.py
@@ -671,9 +671,12 @@ def main() -> None:
     # the boundary scrobble, preventing it from being re-fetched and written
     # into a new Parquet file (which would silently accumulate duplicates).
     save_last_uts(max_uts_seen + 1)
-    # Clear any prior staleness now that new scrobbles were successfully ingested.
+    # Only clear prior staleness when max_uts_seen is strictly newer than the
+    # last persisted timestamp. An ad-hoc replay (--from/--since earlier than
+    # the saved timestamp) may return rows whose max_uts_seen <= persisted_uts,
+    # which does not prove that scrobbling has resumed.
     stale_state = load_staleness_state()
-    if stale_state.get("stale"):
+    if stale_state.get("stale") and (persisted_uts is None or max_uts_seen > persisted_uts):
         save_staleness_state({"stale": False, "stale_since": None})
         update_catalog_staleness(stale=False, stale_since=None)
     clear_checkpoint()

--- a/music-history/scripts/lastfm_ingest.py
+++ b/music-history/scripts/lastfm_ingest.py
@@ -6,6 +6,7 @@ import datetime as dt
 import json
 import os
 import re
+import sys
 import time
 import urllib.error
 from pathlib import Path
@@ -31,6 +32,18 @@ DEFAULT_CURATED_ROOT = Path(
 STATE_DIR = Path.home() / ".local" / "share" / "datalake"
 STATE_FILE = STATE_DIR / "lastfm_last_uts.txt"
 CHECKPOINT_FILE = STATE_DIR / "lastfm_ingest_checkpoint.json"
+STALENESS_STATE_FILE = STATE_DIR / "lastfm_staleness.json"
+
+# Days without a new scrobble before the ingest is declared stale and exits non-zero.
+STALE_THRESHOLD_DAYS: int = 7
+
+# Catalog YAML that downstream tools read for dataset metadata.
+CATALOG_FILE = Path(
+    os.environ.get(
+        "LASTFM_CATALOG_FILE",
+        str(Path.home() / "datalake.me" / "catalog" / "lastfm.yaml"),
+    )
+)
 
 
 def parse_date(value: str) -> int:
@@ -109,6 +122,98 @@ def load_last_uts(state_file: Path = STATE_FILE) -> int:
 def save_last_uts(value: int, state_file: Path = STATE_FILE) -> None:
     state_file.parent.mkdir(parents=True, exist_ok=True)
     state_file.write_text(str(value))
+
+
+def load_persisted_uts(state_file: Path = STATE_FILE) -> int | None:
+    """Return the persisted last-scrobble UTS, or *None* when no state file exists yet.
+
+    Unlike :func:`load_last_uts`, this never synthesises a fallback value, so
+    callers can distinguish "never seen a scrobble" from "last scrobble was N
+    days ago".
+    """
+    if state_file.exists():
+        try:
+            return int(state_file.read_text().strip())
+        except ValueError:
+            pass
+    return None
+
+
+def load_staleness_state(
+    staleness_file: Path = STALENESS_STATE_FILE,
+) -> dict[str, Any]:
+    """Load the persisted staleness state dict.
+
+    Returns ``{"stale": False, "stale_since": None}`` if the file is absent
+    or unreadable.
+    """
+    if staleness_file.exists():
+        try:
+            with staleness_file.open("r", encoding="utf-8") as handle:
+                return json.load(handle)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {"stale": False, "stale_since": None}
+
+
+def save_staleness_state(
+    state: dict[str, Any],
+    staleness_file: Path = STALENESS_STATE_FILE,
+) -> None:
+    staleness_file.parent.mkdir(parents=True, exist_ok=True)
+    with staleness_file.open("w", encoding="utf-8") as handle:
+        json.dump(state, handle, sort_keys=True)
+
+
+def update_catalog_staleness(
+    stale: bool,
+    stale_since: str | None,
+    catalog_file: Path = CATALOG_FILE,
+) -> None:
+    """Upsert ``stale`` and ``stale_since`` fields in the Last.fm YAML catalog.
+
+    Operates on raw text so PyYAML is not required as a dependency.  Only
+    top-level scalar lines that begin with ``stale:`` or ``stale_since:`` are
+    touched; the rest of the file is preserved byte-for-byte.
+    If the file does not exist the function returns silently.
+    """
+    if not catalog_file.exists():
+        return
+
+    stale_val = "true" if stale else "false"
+    stale_since_val = f'"{stale_since}"' if stale_since else "null"
+
+    lines = catalog_file.read_text(encoding="utf-8").splitlines(keepends=True)
+    out: list[str] = []
+    stale_written = False
+    stale_since_written = False
+
+    for line in lines:
+        if line.startswith("stale_since:"):
+            out.append(f"stale_since: {stale_since_val}\n")
+            stale_since_written = True
+        elif line.startswith("stale:"):
+            out.append(f"stale: {stale_val}\n")
+            stale_written = True
+        else:
+            out.append(line)
+
+    # If neither field existed yet, insert them before the ``fields:`` block
+    # (or at the very end of the file when no such block exists).
+    if not stale_written or not stale_since_written:
+        insert_idx = len(out)
+        for i, line in enumerate(out):
+            if line.startswith("fields:"):
+                insert_idx = i
+                break
+        new_lines: list[str] = []
+        if not stale_written:
+            new_lines.append(f"stale: {stale_val}\n")
+        if not stale_since_written:
+            new_lines.append(f"stale_since: {stale_since_val}\n")
+        out[insert_idx:insert_idx] = new_lines
+
+    catalog_file.write_text("".join(out), encoding="utf-8")
 
 
 def load_checkpoint(checkpoint_file: Path = CHECKPOINT_FILE) -> dict[str, Any] | None:
@@ -441,6 +546,9 @@ def main() -> None:
     raw_root = Path(os.getenv("DATALAKE_RAW_ROOT", str(DEFAULT_RAW_ROOT))) / "lastfm"
     curated_root = Path(os.getenv("DATALAKE_CURATED_ROOT", str(DEFAULT_CURATED_ROOT))) / "lastfm" / "scrobbles"
 
+    # Keep the raw persisted value separately so staleness detection can
+    # distinguish "first ever run" from "last scrobble was N days ago".
+    persisted_uts = load_persisted_uts()
     checkpoint = None if args.no_resume else load_checkpoint()
     loaded_state_uts = load_last_uts_if_valid()
     # Intentional: when the state file is missing or corrupted, fall back to unix epoch 0
@@ -530,12 +638,44 @@ def main() -> None:
     if max_uts_seen is None:
         clear_checkpoint()
         print("No new rows found.")
+
+        # --- Staleness detection ---
+        # Only fire when we have a real persisted timestamp (i.e. we have
+        # ingested at least once before) and the gap exceeds the threshold.
+        if persisted_uts is not None:
+            gap_days = (int(time.time()) - persisted_uts) / 86400.0
+            if gap_days >= STALE_THRESHOLD_DAYS:
+                # Persist stale_since on first detection; keep it on subsequent runs.
+                stale_state = load_staleness_state()
+                if not stale_state.get("stale"):
+                    today = dt.datetime.now(tz=dt.UTC).strftime("%Y-%m-%d")
+                    stale_state = {"stale": True, "stale_since": today}
+                    save_staleness_state(stale_state)
+                stale_since = stale_state["stale_since"]
+                update_catalog_staleness(stale=True, stale_since=stale_since)
+                last_date = dt.datetime.fromtimestamp(
+                    persisted_uts, tz=dt.UTC
+                ).strftime("%Y-%m-%d")
+                gap_int = int(gap_days)
+                print(
+                    f"ERROR: No new Last.fm scrobbles detected for {gap_int} days "
+                    f"(last scrobble: {last_date}, threshold: {STALE_THRESHOLD_DAYS}d). "
+                    "Check that the scrobbling source is still connected at "
+                    "https://www.last.fm/settings/applications",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
         return
 
     # Advance by 1 second so the next incremental run starts strictly after
     # the boundary scrobble, preventing it from being re-fetched and written
     # into a new Parquet file (which would silently accumulate duplicates).
     save_last_uts(max_uts_seen + 1)
+    # Clear any prior staleness now that new scrobbles were successfully ingested.
+    stale_state = load_staleness_state()
+    if stale_state.get("stale"):
+        save_staleness_state({"stale": False, "stale_since": None})
+        update_catalog_staleness(stale=False, stale_since=None)
     clear_checkpoint()
     print(
         f"Ingest complete: pages={pages_processed}, parquet_rows={rows_written}, "

--- a/music-history/tests/test_lastfm_ingest.py
+++ b/music-history/tests/test_lastfm_ingest.py
@@ -942,3 +942,91 @@ def test_main_uses_zero_fallback_for_paginated_curated_output_without_state_or_c
     lastfm_ingest.main()
 
     assert fallback_from_uts == [0]
+
+
+# ---------------------------------------------------------------------------
+# Staleness-detection helpers
+# ---------------------------------------------------------------------------
+
+def test_load_persisted_uts_returns_none_when_state_file_absent(tmp_path: Path) -> None:
+    assert lastfm_ingest.load_persisted_uts(state_file=tmp_path / "missing.txt") is None
+
+
+def test_load_persisted_uts_returns_value_when_state_file_present(tmp_path: Path) -> None:
+    state_file = tmp_path / "last_uts.txt"
+    state_file.write_text("1779334414")
+    assert lastfm_ingest.load_persisted_uts(state_file=state_file) == 1779334414
+
+
+def test_load_staleness_state_returns_defaults_when_absent(tmp_path: Path) -> None:
+    result = lastfm_ingest.load_staleness_state(staleness_file=tmp_path / "missing.json")
+    assert result == {"stale": False, "stale_since": None}
+
+
+def test_save_and_load_staleness_state_roundtrip(tmp_path: Path) -> None:
+    state_file = tmp_path / "staleness.json"
+    payload = {"stale": True, "stale_since": "2026-06-01"}
+    lastfm_ingest.save_staleness_state(payload, staleness_file=state_file)
+    result = lastfm_ingest.load_staleness_state(staleness_file=state_file)
+    assert result["stale"] is True
+    assert result["stale_since"] == "2026-06-01"
+
+
+# ---------------------------------------------------------------------------
+# update_catalog_staleness
+# ---------------------------------------------------------------------------
+
+def test_update_catalog_staleness_adds_fields_when_absent(tmp_path: Path) -> None:
+    catalog = tmp_path / "lastfm.yaml"
+    catalog.write_text(
+        'source: lastfm\nlatest: "2026-05-21"\nfields:\n  - name: track name\n'
+    )
+    lastfm_ingest.update_catalog_staleness(True, "2026-06-01", catalog_file=catalog)
+    text = catalog.read_text()
+    assert "stale: true\n" in text
+    assert 'stale_since: "2026-06-01"\n' in text
+    # Fields block should still come after the inserted lines
+    assert text.index("fields:") > text.index("stale: true")
+
+
+def test_update_catalog_staleness_updates_existing_fields(tmp_path: Path) -> None:
+    catalog = tmp_path / "lastfm.yaml"
+    catalog.write_text(
+        "source: lastfm\nstale: false\nstale_since: null\nfields:\n  - name: track name\n"
+    )
+    lastfm_ingest.update_catalog_staleness(True, "2026-06-10", catalog_file=catalog)
+    text = catalog.read_text()
+    assert "stale: true\n" in text
+    assert 'stale_since: "2026-06-10"\n' in text
+    # Each field should appear exactly once
+    assert text.count("stale: ") == 1
+    assert text.count("stale_since: ") == 1
+
+
+def test_update_catalog_staleness_clears_stale_flag(tmp_path: Path) -> None:
+    catalog = tmp_path / "lastfm.yaml"
+    catalog.write_text(
+        'source: lastfm\nstale: true\nstale_since: "2026-06-01"\nfields:\n  - name: track name\n'
+    )
+    lastfm_ingest.update_catalog_staleness(False, None, catalog_file=catalog)
+    text = catalog.read_text()
+    assert "stale: false\n" in text
+    assert "stale_since: null\n" in text
+
+
+def test_update_catalog_staleness_no_op_when_catalog_absent(tmp_path: Path) -> None:
+    # Should not raise even if the file doesn't exist
+    lastfm_ingest.update_catalog_staleness(True, "2026-06-01", catalog_file=tmp_path / "absent.yaml")
+
+
+def test_update_catalog_staleness_stale_since_not_confused_with_stale(tmp_path: Path) -> None:
+    """Ensure stale_since: line is not accidentally matched by the stale: handler."""
+    catalog = tmp_path / "lastfm.yaml"
+    catalog.write_text("source: lastfm\nstale_since: null\nstale: false\n")
+    lastfm_ingest.update_catalog_staleness(True, "2026-06-15", catalog_file=catalog)
+    text = catalog.read_text()
+    assert text.count("stale: ") == 1
+    assert text.count("stale_since: ") == 1
+    assert "stale: true\n" in text
+    assert 'stale_since: "2026-06-15"\n' in text
+

--- a/music-history/tests/test_lastfm_ingest.py
+++ b/music-history/tests/test_lastfm_ingest.py
@@ -1030,3 +1030,75 @@ def test_update_catalog_staleness_stale_since_not_confused_with_stale(tmp_path: 
     assert "stale: true\n" in text
     assert 'stale_since: "2026-06-15"\n' in text
 
+
+# ---------------------------------------------------------------------------
+# Staleness-clear boundary: max_uts_seen vs persisted_uts
+# ---------------------------------------------------------------------------
+
+def test_stale_flag_not_cleared_when_max_uts_equals_persisted(tmp_path: Path) -> None:
+    """Ad-hoc replay returning equal timestamp must NOT clear the stale flag.
+
+    When --from/--since is set earlier than the saved checkpoint, fetched rows
+    may have max_uts_seen == persisted_uts (a replay of existing data).  The
+    stale flag must remain set in this case because scrobbling has not resumed.
+    """
+    staleness_file = tmp_path / "staleness.json"
+    lastfm_ingest.save_staleness_state(
+        {"stale": True, "stale_since": "2026-06-01"}, staleness_file=staleness_file
+    )
+
+    persisted_uts = 1_750_000_000
+    max_uts_seen = persisted_uts  # equal — replay, not genuinely new data
+
+    stale_state = lastfm_ingest.load_staleness_state(staleness_file=staleness_file)
+    # Mirrors the fixed condition in main()
+    if stale_state.get("stale") and (persisted_uts is None or max_uts_seen > persisted_uts):
+        lastfm_ingest.save_staleness_state(
+            {"stale": False, "stale_since": None}, staleness_file=staleness_file
+        )
+
+    result = lastfm_ingest.load_staleness_state(staleness_file=staleness_file)
+    assert result["stale"] is True, "Stale flag must stay set after a replay with no new data"
+    assert result["stale_since"] == "2026-06-01"
+
+
+def test_stale_flag_not_cleared_when_max_uts_older_than_persisted(tmp_path: Path) -> None:
+    """Ad-hoc replay returning older timestamp must NOT clear the stale flag."""
+    staleness_file = tmp_path / "staleness.json"
+    lastfm_ingest.save_staleness_state(
+        {"stale": True, "stale_since": "2026-06-01"}, staleness_file=staleness_file
+    )
+
+    persisted_uts = 1_750_000_000
+    max_uts_seen = persisted_uts - 1  # older than saved checkpoint
+
+    stale_state = lastfm_ingest.load_staleness_state(staleness_file=staleness_file)
+    if stale_state.get("stale") and (persisted_uts is None or max_uts_seen > persisted_uts):
+        lastfm_ingest.save_staleness_state(
+            {"stale": False, "stale_since": None}, staleness_file=staleness_file
+        )
+
+    result = lastfm_ingest.load_staleness_state(staleness_file=staleness_file)
+    assert result["stale"] is True, "Stale flag must stay set when max_uts_seen < persisted_uts"
+
+
+def test_stale_flag_cleared_when_max_uts_strictly_newer(tmp_path: Path) -> None:
+    """Genuine new scrobble (max_uts_seen > persisted_uts) clears the stale flag."""
+    staleness_file = tmp_path / "staleness.json"
+    lastfm_ingest.save_staleness_state(
+        {"stale": True, "stale_since": "2026-06-01"}, staleness_file=staleness_file
+    )
+
+    persisted_uts = 1_750_000_000
+    max_uts_seen = persisted_uts + 1  # strictly newer — real resume
+
+    stale_state = lastfm_ingest.load_staleness_state(staleness_file=staleness_file)
+    if stale_state.get("stale") and (persisted_uts is None or max_uts_seen > persisted_uts):
+        lastfm_ingest.save_staleness_state(
+            {"stale": False, "stale_since": None}, staleness_file=staleness_file
+        )
+
+    result = lastfm_ingest.load_staleness_state(staleness_file=staleness_file)
+    assert result["stale"] is False, "Stale flag must be cleared when max_uts_seen > persisted_uts"
+    assert result["stale_since"] is None
+

--- a/music-history/tests/test_lastfm_ingest.py
+++ b/music-history/tests/test_lastfm_ingest.py
@@ -743,6 +743,7 @@ def test_main_skips_curated_scan_when_state_file_exists(
     ))
     monkeypatch.setattr(lastfm_ingest, "load_env", lambda _name: "value")
     monkeypatch.setattr(lastfm_ingest, "load_last_uts_if_valid", lambda: 123)
+    monkeypatch.setattr(lastfm_ingest, "load_persisted_uts", lambda **_kw: None)
     monkeypatch.setattr(lastfm_ingest, "load_checkpoint", lambda: None)
     monkeypatch.setattr(lastfm_ingest, "load_seen_keys_for_run", lambda **_kwargs: set())
     monkeypatch.setattr(
@@ -782,6 +783,7 @@ def test_main_scans_curated_when_state_file_missing(
     ))
     monkeypatch.setattr(lastfm_ingest, "load_env", lambda _name: "value")
     monkeypatch.setattr(lastfm_ingest, "load_last_uts_if_valid", lambda: None)
+    monkeypatch.setattr(lastfm_ingest, "load_persisted_uts", lambda **_kw: None)
     monkeypatch.setattr(lastfm_ingest, "load_checkpoint", lambda: None)
     monkeypatch.setattr(lastfm_ingest, "has_paginated_curated_output", lambda **_kwargs: False)
     monkeypatch.setattr(lastfm_ingest, "load_seen_keys_for_run", lambda **_kwargs: set())
@@ -827,6 +829,7 @@ def test_main_scans_curated_when_state_file_invalid(
     ))
     monkeypatch.setattr(lastfm_ingest, "load_env", lambda _name: "value")
     monkeypatch.setattr(lastfm_ingest, "load_last_uts_if_valid", lambda: None)
+    monkeypatch.setattr(lastfm_ingest, "load_persisted_uts", lambda **_kw: None)
     monkeypatch.setattr(lastfm_ingest, "load_checkpoint", lambda: None)
     monkeypatch.setattr(lastfm_ingest, "has_paginated_curated_output", lambda **_kwargs: False)
     monkeypatch.setattr(lastfm_ingest, "load_seen_keys_for_run", lambda **_kwargs: set())
@@ -871,6 +874,7 @@ def test_main_skips_curated_scan_when_checkpoint_is_usable(
     ))
     monkeypatch.setattr(lastfm_ingest, "load_env", lambda _name: "value")
     monkeypatch.setattr(lastfm_ingest, "load_last_uts_if_valid", lambda: None)
+    monkeypatch.setattr(lastfm_ingest, "load_persisted_uts", lambda **_kw: None)
     monkeypatch.setattr(
         lastfm_ingest,
         "load_checkpoint",
@@ -914,6 +918,7 @@ def test_main_uses_zero_fallback_for_paginated_curated_output_without_state_or_c
     ))
     monkeypatch.setattr(lastfm_ingest, "load_env", lambda _name: "value")
     monkeypatch.setattr(lastfm_ingest, "load_last_uts_if_valid", lambda: None)
+    monkeypatch.setattr(lastfm_ingest, "load_persisted_uts", lambda **_kw: None)
     monkeypatch.setattr(lastfm_ingest, "load_checkpoint", lambda: None)
     monkeypatch.setattr(lastfm_ingest, "has_paginated_curated_output", lambda **_kwargs: True)
     monkeypatch.setattr(lastfm_ingest, "load_seen_keys_for_run", lambda **_kwargs: set())


### PR DESCRIPTION
## Summary

The daily Last.fm ingest was silently succeeding when no new scrobbles came back, making it impossible for the pipeline to distinguish *"caught up"* from *"scrobbling is broken"*.  
Issue #72 reported a 34-day gap (last scrobble 2026-05-21) with no alert.

### Changes

**`music-history/scripts/lastfm_ingest.py`**

| Addition | Purpose |
|---|---|
| `STALE_THRESHOLD_DAYS = 7` | Configurable threshold constant |
| `CATALOG_FILE` | Path to `~/datalake.me/catalog/lastfm.yaml` (overridable via `LASTFM_CATALOG_FILE`) |
| `load_persisted_uts()` | None-safe read of the state file — lets us distinguish *first run* from *stale* |
| `load_staleness_state()` | Loads `~/.local/share/datalake/lastfm_staleness.json` |
| `save_staleness_state()` | Persists `{stale, stale_since}` across runs |
| `update_catalog_staleness()` | Pure-text upsert of `stale:` / `stale_since:` in the YAML catalog (no PyYAML dep) |
| Staleness branch in `main()` | On no new scrobbles + gap ≥ threshold: updates catalog, prints `ERROR` to stderr, exits 1 |
| Clear-on-recovery in `main()` | Resets `stale: false` / `stale_since: null` when new scrobbles are found after a stale period |

**`music-history/tests/test_lastfm_ingest.py`** — 9 new tests covering all helpers and edge cases.

## Verification steps

1. **Normal incremental run (no staleness):** No change in exit code or catalog.
2. **Stale run simulation:**
   - Set `STATE_FILE` to a UTS > 7 days ago.
   - Run `scripts/lastfm_ingest.py` in an environment where no new scrobbles exist.
   - Expect: exit code 1, `ERROR` on stderr, `stale: true` + `stale_since:` written to `lastfm.yaml`.
3. **Recovery:** When scrobbling resumes and the ingest picks up rows, expect: `stale: false`, `stale_since: null` in catalog.
4. **Tests:** `cd ~/code/tools && uv run --project music-history pytest music-history/ -q` → 43 passed.

## What this does NOT fix

The root cause (scrobbling source disconnected on the user's device) requires user action per the issue body: verify the scrobbling app at <https://www.last.fm/settings/applications> and confirm tracks appear at <https://www.last.fm/user/clakesnapster>. The next daily ingest will automatically pick up history once scrobbling resumes.

Fixes mohit/tools#72