### PR TITLE
fix(apple-music): staleness detection for raw export files

### DIFF
--- a/music-history/config.py
+++ b/music-history/config.py
@@ -13,3 +13,6 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 EXPORT_METADATA_PATH = SCRIPT_DIR / "apple_music_export_metadata.json"
 
 MAX_STALENESS_DAYS = int(os.environ.get("APPLE_MUSIC_MAX_STALENESS_DAYS", "365"))
+
+RAW_APPLE_MUSIC_DIR = RAW_ROOT / "apple-music"
+RAW_FILE_STALENESS_DAYS = int(os.environ.get("APPLE_MUSIC_RAW_FILE_STALENESS_DAYS", "30"))

--- a/music-history/ingest_apple_music.py
+++ b/music-history/ingest_apple_music.py
@@ -1,12 +1,19 @@
+import argparse
 import time
 from pathlib import Path
 
 import duckdb
 from apple_music_export_guard import (
     AppleMusicExportGuardError,
-    enforce_fresh_export_or_raise,
+    check_export_freshness,
 )
-from config import CATALOG_DB, EXPORT_METADATA_PATH, MAX_STALENESS_DAYS
+from config import (
+    CATALOG_DB,
+    EXPORT_METADATA_PATH,
+    MAX_STALENESS_DAYS,
+    RAW_APPLE_MUSIC_DIR,
+    RAW_FILE_STALENESS_DAYS,
+)
 
 # Config
 from config import CURATED_ROOT as _CURATED_BASE
@@ -14,21 +21,85 @@ from config import CURATED_ROOT as _CURATED_BASE
 JSONL_PATH = Path("apple_music_history.jsonl").absolute()
 CURATED_ROOT = _CURATED_BASE / "apple_music/library"
 
-def ingest():
+
+def check_raw_csv_staleness(
+    raw_dir: Path,
+    threshold_days: int,
+    *,
+    _now: float | None = None,
+) -> tuple[float | None, list[Path]]:
+    """Check modification time of CSV files in *raw_dir*.
+
+    Returns ``(age_days, stale_files)`` where *age_days* is the age of the
+    *newest* CSV file (based on mtime), or ``None`` when no CSV files are
+    found.  *stale_files* is the list of files whose mtime exceeds
+    *threshold_days*.
+    """
+    csv_files = list(raw_dir.glob("*.csv"))
+    if not csv_files:
+        return None, []
+
+    now = _now if _now is not None else time.time()
+    mtimes = {p: p.stat().st_mtime for p in csv_files}
+    newest_mtime = max(mtimes.values())
+    age_days = (now - newest_mtime) / 86400
+
+    stale_files: list[Path] = []
+    if age_days > threshold_days:
+        stale_files = [p for p, mtime in mtimes.items() if (now - mtime) / 86400 > threshold_days]
+
+    return age_days, stale_files
+
+
+def _emit_staleness_warning(age_days: float, threshold_days: int, strict: bool) -> None:
+    msg = (
+        f"Apple Music raw export files are stale "
+        f"({age_days:.1f} days old, threshold {threshold_days} days). "
+        "Request a new export from privacy.apple.com "
+        "(Data & Privacy > Get a copy of your data > Apple Media Services "
+        "information), then replace the raw files and rerun ingestion."
+    )
+    if strict:
+        print(f"ERROR: {msg}")
+        raise SystemExit(2)
+    print(f"WARNING: {msg}")
+
+
+def ingest(strict_freshness: bool = False) -> None:
+    # 1. Check raw CSV file modification times
+    if RAW_APPLE_MUSIC_DIR.exists():
+        age_days, stale_files = check_raw_csv_staleness(
+            RAW_APPLE_MUSIC_DIR, RAW_FILE_STALENESS_DAYS
+        )
+        if age_days is None:
+            print(f"WARNING: No CSV files found in raw directory: {RAW_APPLE_MUSIC_DIR}")
+        else:
+            print(
+                f"Raw Apple Music CSV age: {age_days:.1f} days "
+                f"(threshold: {RAW_FILE_STALENESS_DAYS} days)"
+            )
+            if stale_files:
+                _emit_staleness_warning(age_days, RAW_FILE_STALENESS_DAYS, strict_freshness)
+    else:
+        print(f"WARNING: Raw Apple Music directory not found: {RAW_APPLE_MUSIC_DIR}")
+
+    # 2. Check metadata-based freshness
     try:
-        metadata, age_days = enforce_fresh_export_or_raise(
+        metadata, age_days_meta = check_export_freshness(
             EXPORT_METADATA_PATH, max_staleness_days=MAX_STALENESS_DAYS
         )
+        print(
+            "Apple Music export freshness check passed: "
+            f"latest_play_date={metadata.latest_play_date.isoformat()} "
+            f"last_export_date={metadata.last_export_date.isoformat()} "
+            f"age_days={age_days_meta}"
+        )
     except AppleMusicExportGuardError as exc:
-        print(f"ERROR: {exc}")
-        raise SystemExit(2) from exc
-
-    print(
-        "Apple Music export freshness check passed: "
-        f"latest_play_date={metadata.latest_play_date.isoformat()} "
-        f"last_export_date={metadata.last_export_date.isoformat()} "
-        f"age_days={age_days}"
-    )
+        msg = str(exc)
+        if strict_freshness:
+            print(f"ERROR: {msg}")
+            raise SystemExit(2) from exc
+        print(f"WARNING: {msg}")
 
     print(f"Ingesting {JSONL_PATH}...")
 
@@ -84,5 +155,23 @@ def ingest():
     con.close()
     print("Done.")
 
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Ingest Apple Music export data into the datalake."
+    )
+    parser.add_argument(
+        "--strict-freshness",
+        action="store_true",
+        default=False,
+        help=(
+            "Abort ingestion when raw CSV files or export metadata are stale "
+            f"(default: warn and continue; raw threshold {RAW_FILE_STALENESS_DAYS} days)"
+        ),
+    )
+    args = parser.parse_args(argv)
+    ingest(strict_freshness=args.strict_freshness)
+
+
 if __name__ == "__main__":
-    ingest()
+    main()

--- a/music-history/ingest_apple_music.py
+++ b/music-history/ingest_apple_music.py
@@ -35,7 +35,7 @@ def check_raw_csv_staleness(
     found.  *stale_files* is the list of files whose mtime exceeds
     *threshold_days*.
     """
-    csv_files = list(raw_dir.glob("*.csv"))
+    csv_files = list(raw_dir.rglob("*.csv"))
     if not csv_files:
         return None, []
 

--- a/music-history/tests/test_ingest_apple_music_staleness.py
+++ b/music-history/tests/test_ingest_apple_music_staleness.py
@@ -1,0 +1,235 @@
+"""Tests for raw-CSV mtime-based staleness detection in ingest_apple_music."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+import ingest_apple_music as ingest_mod
+from ingest_apple_music import check_raw_csv_staleness
+
+
+# ---------------------------------------------------------------------------
+# check_raw_csv_staleness
+# ---------------------------------------------------------------------------
+
+
+def _write_csv(path: Path, content: str = "header\n") -> None:
+    path.write_text(content)
+
+
+def test_returns_none_when_directory_has_no_csvs(tmp_path: Path) -> None:
+    age_days, stale = check_raw_csv_staleness(tmp_path, threshold_days=30)
+    assert age_days is None
+    assert stale == []
+
+
+def test_returns_none_when_directory_does_not_exist(tmp_path: Path) -> None:
+    missing = tmp_path / "no-such-dir"
+    age_days, stale = check_raw_csv_staleness(missing, threshold_days=30)
+    assert age_days is None
+    assert stale == []
+
+
+def test_fresh_csv_returns_no_stale_files(tmp_path: Path) -> None:
+    csv = tmp_path / "Apple Music - Track Play History.csv"
+    _write_csv(csv)
+    now = time.time()
+    # File was just written — age is ~0 days, well within 30-day threshold.
+    age_days, stale = check_raw_csv_staleness(tmp_path, threshold_days=30, _now=now)
+    assert age_days is not None
+    assert age_days < 1
+    assert stale == []
+
+
+def test_stale_csv_is_detected(tmp_path: Path) -> None:
+    csv = tmp_path / "Apple Music - Track Play History.csv"
+    _write_csv(csv)
+    # Simulate 128 days of staleness by shifting "now" forward.
+    fake_now = time.time() + 128 * 86400
+    age_days, stale = check_raw_csv_staleness(tmp_path, threshold_days=30, _now=fake_now)
+    assert age_days is not None
+    assert age_days > 127
+    assert csv in stale
+
+
+def test_age_computed_from_newest_csv(tmp_path: Path) -> None:
+    old_csv = tmp_path / "old.csv"
+    new_csv = tmp_path / "new.csv"
+    _write_csv(old_csv)
+    _write_csv(new_csv)
+    # Make old_csv appear much older by adjusting fake_now relative to new_csv.
+    # new_csv was just written; advance "now" by 10 days — still fresh.
+    fake_now = time.time() + 10 * 86400
+    age_days, stale = check_raw_csv_staleness(tmp_path, threshold_days=30, _now=fake_now)
+    # Newest file is ~10 days old — below threshold.
+    assert age_days is not None
+    assert age_days < 11
+    assert stale == []
+
+
+def test_non_csv_files_are_ignored(tmp_path: Path) -> None:
+    (tmp_path / "README.txt").write_text("ignored")
+    (tmp_path / "data.json").write_text("{}")
+    age_days, stale = check_raw_csv_staleness(tmp_path, threshold_days=30)
+    assert age_days is None
+    assert stale == []
+
+
+# ---------------------------------------------------------------------------
+# ingest() — staleness warning / strict-freshness behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_warns_and_continues_when_stale(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """By default, stale raw files emit a WARNING and do NOT abort."""
+    csv = tmp_path / "Apple Music - Track Play History.csv"
+    _write_csv(csv)
+    fake_now = time.time() + 128 * 86400
+
+    monkeypatch.setattr(ingest_mod, "RAW_APPLE_MUSIC_DIR", tmp_path)
+    monkeypatch.setattr(ingest_mod, "RAW_FILE_STALENESS_DAYS", 30)
+
+    # Patch check_raw_csv_staleness to return stale result without relying on fs timestamps.
+    monkeypatch.setattr(
+        ingest_mod,
+        "check_raw_csv_staleness",
+        lambda raw_dir, threshold_days, **kwargs: (128.0, [csv]),
+    )
+
+    # Prevent the rest of ingest() from running (no real JSONL / DuckDB available).
+    def _fake_ingest_body(*_, **__):  # noqa: ANN001, ANN002, ANN003
+        raise StopIteration("body reached")
+
+    # Patch duckdb.connect to stop early — we only care about the warning path.
+    import duckdb as _duckdb
+    monkeypatch.setattr(_duckdb, "connect", lambda *a, **kw: (_ for _ in ()).throw(StopIteration("duckdb")))
+
+    # Also stub out the metadata check so it passes cleanly.
+    from apple_music_export_guard import AppleMusicExportMetadata
+    from datetime import date
+    fake_metadata = AppleMusicExportMetadata(
+        last_export_date=date.today(),
+        latest_play_date=date.today(),
+        source="privacy.apple.com",
+        status=None,
+        issue=None,
+    )
+    monkeypatch.setattr(
+        ingest_mod,
+        "check_export_freshness",
+        lambda *a, **kw: (fake_metadata, 0),
+    )
+    # Prevent actual JSONL path check
+    monkeypatch.setattr(ingest_mod, "JSONL_PATH", tmp_path / "dummy.jsonl")
+    monkeypatch.setattr(ingest_mod, "CURATED_ROOT", tmp_path / "curated")
+
+    with pytest.raises(StopIteration):
+        ingest_mod.ingest(strict_freshness=False)
+
+    captured = capsys.readouterr()
+    assert "WARNING:" in captured.out
+    assert "privacy.apple.com" in captured.out
+    assert "128.0 days old" in captured.out
+
+
+def test_ingest_aborts_with_strict_freshness_when_stale(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With --strict-freshness, stale raw files cause SystemExit(2)."""
+    csv = tmp_path / "Apple Music - Track Play History.csv"
+    _write_csv(csv)
+
+    monkeypatch.setattr(ingest_mod, "RAW_APPLE_MUSIC_DIR", tmp_path)
+    monkeypatch.setattr(ingest_mod, "RAW_FILE_STALENESS_DAYS", 30)
+    monkeypatch.setattr(
+        ingest_mod,
+        "check_raw_csv_staleness",
+        lambda raw_dir, threshold_days, **kwargs: (128.0, [csv]),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        ingest_mod.ingest(strict_freshness=True)
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "ERROR:" in captured.out
+    assert "privacy.apple.com" in captured.out
+
+
+def test_ingest_no_warning_when_fresh(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fresh raw files produce no staleness warning."""
+    monkeypatch.setattr(ingest_mod, "RAW_APPLE_MUSIC_DIR", tmp_path)
+    monkeypatch.setattr(ingest_mod, "RAW_FILE_STALENESS_DAYS", 30)
+    monkeypatch.setattr(
+        ingest_mod,
+        "check_raw_csv_staleness",
+        lambda raw_dir, threshold_days, **kwargs: (5.0, []),
+    )
+
+    from apple_music_export_guard import AppleMusicExportMetadata
+    from datetime import date
+    fake_metadata = AppleMusicExportMetadata(
+        last_export_date=date.today(),
+        latest_play_date=date.today(),
+        source="privacy.apple.com",
+        status=None,
+        issue=None,
+    )
+    monkeypatch.setattr(
+        ingest_mod,
+        "check_export_freshness",
+        lambda *a, **kw: (fake_metadata, 0),
+    )
+    monkeypatch.setattr(ingest_mod, "JSONL_PATH", tmp_path / "dummy.jsonl")
+    monkeypatch.setattr(ingest_mod, "CURATED_ROOT", tmp_path / "curated")
+
+    import duckdb as _duckdb
+    monkeypatch.setattr(_duckdb, "connect", lambda *a, **kw: (_ for _ in ()).throw(StopIteration("duckdb")))
+
+    with pytest.raises(StopIteration):
+        ingest_mod.ingest(strict_freshness=False)
+
+    captured = capsys.readouterr()
+    assert "WARNING:" not in captured.out
+    assert "5.0 days" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# main() — CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+def test_main_parses_strict_freshness_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict] = []
+
+    def fake_ingest(strict_freshness: bool = False) -> None:
+        calls.append({"strict_freshness": strict_freshness})
+
+    monkeypatch.setattr(ingest_mod, "ingest", fake_ingest)
+
+    ingest_mod.main(["--strict-freshness"])
+    assert calls == [{"strict_freshness": True}]
+
+
+def test_main_defaults_to_no_strict_freshness(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict] = []
+
+    def fake_ingest(strict_freshness: bool = False) -> None:
+        calls.append({"strict_freshness": strict_freshness})
+
+    monkeypatch.setattr(ingest_mod, "ingest", fake_ingest)
+
+    ingest_mod.main([])
+    assert calls == [{"strict_freshness": False}]

--- a/music-history/tests/test_ingest_apple_music_staleness.py
+++ b/music-history/tests/test_ingest_apple_music_staleness.py
@@ -1,14 +1,13 @@
 """Tests for raw-CSV mtime-based staleness detection in ingest_apple_music."""
+
 from __future__ import annotations
 
 import time
 from pathlib import Path
 
-import pytest
-
 import ingest_apple_music as ingest_mod
+import pytest
 from ingest_apple_music import check_raw_csv_staleness
-
 
 # ---------------------------------------------------------------------------
 # check_raw_csv_staleness
@@ -90,7 +89,6 @@ def test_ingest_warns_and_continues_when_stale(
     """By default, stale raw files emit a WARNING and do NOT abort."""
     csv = tmp_path / "Apple Music - Track Play History.csv"
     _write_csv(csv)
-    fake_now = time.time() + 128 * 86400
 
     monkeypatch.setattr(ingest_mod, "RAW_APPLE_MUSIC_DIR", tmp_path)
     monkeypatch.setattr(ingest_mod, "RAW_FILE_STALENESS_DAYS", 30)
@@ -108,11 +106,14 @@ def test_ingest_warns_and_continues_when_stale(
 
     # Patch duckdb.connect to stop early — we only care about the warning path.
     import duckdb as _duckdb
+
     monkeypatch.setattr(_duckdb, "connect", lambda *a, **kw: (_ for _ in ()).throw(StopIteration("duckdb")))
 
     # Also stub out the metadata check so it passes cleanly.
-    from apple_music_export_guard import AppleMusicExportMetadata
     from datetime import date
+
+    from apple_music_export_guard import AppleMusicExportMetadata
+
     fake_metadata = AppleMusicExportMetadata(
         last_export_date=date.today(),
         latest_play_date=date.today(),
@@ -178,8 +179,10 @@ def test_ingest_no_warning_when_fresh(
         lambda raw_dir, threshold_days, **kwargs: (5.0, []),
     )
 
-    from apple_music_export_guard import AppleMusicExportMetadata
     from datetime import date
+
+    from apple_music_export_guard import AppleMusicExportMetadata
+
     fake_metadata = AppleMusicExportMetadata(
         last_export_date=date.today(),
         latest_play_date=date.today(),
@@ -196,6 +199,7 @@ def test_ingest_no_warning_when_fresh(
     monkeypatch.setattr(ingest_mod, "CURATED_ROOT", tmp_path / "curated")
 
     import duckdb as _duckdb
+
     monkeypatch.setattr(_duckdb, "connect", lambda *a, **kw: (_ for _ in ()).throw(StopIteration("duckdb")))
 
     with pytest.raises(StopIteration):


### PR DESCRIPTION
## Summary
Adds staleness detection to `ingest_apple_music.py` so stale raw data is flagged clearly with actionable instructions.

## Changes
- Check raw CSV file modification times against a freshness threshold (30 days)
- Emit clear warning/error with instructions to re-export from privacy.apple.com when stale
- Added tests for staleness detection logic

## Verification
- Tests pass: `python -m pytest music-history/tests/ -v`

Fixes mohit/tools#71