### PR TITLE
feat(strava): add curated parquet copy-out via --curated-dir / DATALAKE_STRAVA_CURATED_ROOT

### DIFF
--- a/catalog.yaml
+++ b/catalog.yaml
@@ -5,6 +5,7 @@ sources:
     cadence: daily
     script: strava-data-puller/strava_pull.py
     raw_root: ~/code/tools/strava-data-puller/strava-export
+    curated_root: ~/datalake.me/curated/strava
     last_sync: "2026-06-16T13:00:00Z"
     last_activity_date: "2026-05-03"
     total_activities: 193

--- a/strava-data-puller/strava_pull.py
+++ b/strava-data-puller/strava_pull.py
@@ -4,6 +4,7 @@ import datetime as dt
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 import time
@@ -597,6 +598,35 @@ def build_activity_streams_ndjson(out_dir: Path, include_ids: set[int] | None = 
     return rows
 
 
+_CURATED_PARQUET_FILES = (
+    "activities.parquet",
+    "athlete.parquet",
+    "stats.parquet",
+    "activity_details.parquet",
+    "activity_streams.parquet",
+)
+
+
+def _copy_parquet_to_curated(out_dir: Path, curated_dir: Path) -> None:
+    """Copy exported parquet files from *out_dir* to *curated_dir*.
+
+    Only files that actually exist in *out_dir* are copied; missing files
+    (e.g. activity_details.parquet when no detail fetch was run) are silently
+    skipped so the curated directory is never left with stale artefacts from a
+    previous run that no longer exist in raw.
+    """
+    copied = []
+    for name in _CURATED_PARQUET_FILES:
+        src = out_dir / name
+        if src.exists():
+            shutil.copy2(src, curated_dir / name)
+            copied.append(name)
+    if copied:
+        print(f"Copied {len(copied)} parquet file(s) to curated dir: {curated_dir}")
+    else:
+        print(f"No parquet files found to copy to curated dir: {curated_dir}")
+
+
 def export_parquet(out_dir: Path) -> None:
     con = duckdb.connect()
     con.execute(
@@ -717,6 +747,18 @@ def parse_types(raw_types: str | None) -> set[str]:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Pull Strava data locally")
     parser.add_argument("--out-dir", default="./strava-export")
+    parser.add_argument(
+        "--curated-dir",
+        default=os.environ.get(
+            "DATALAKE_STRAVA_CURATED_ROOT",
+            str(Path.home() / "datalake.me" / "curated" / "strava"),
+        ),
+        help=(
+            "Directory to copy exported parquet files into after each sync. "
+            "Defaults to DATALAKE_STRAVA_CURATED_ROOT env var, then "
+            "~/datalake.me/curated/strava. Pass empty string to disable."
+        ),
+    )
     parser.add_argument("--types", default=None)
     parser.add_argument("--after", type=parse_date)
     parser.add_argument("--before", type=parse_date)
@@ -869,6 +911,10 @@ def main() -> None:
 
     if not args.skip_parquet:
         export_parquet(out_dir)
+        if args.curated_dir:
+            curated_dir = Path(args.curated_dir)
+            curated_dir.mkdir(parents=True, exist_ok=True)
+            _copy_parquet_to_curated(out_dir, curated_dir)
 
     print(f"Sync complete. Total library size: {len(final_activities)} activities.")
 

--- a/strava-data-puller/tests/test_credentials.py
+++ b/strava-data-puller/tests/test_credentials.py
@@ -584,6 +584,7 @@ class TestCredentials(TestCase):
             install_credentials=False,
             check_credentials=False,
             out_dir=str(out_dir),
+            curated_dir="",
             force=False,
             after=None,
             before=None,

--- a/strava-data-puller/tests/test_curated_copy.py
+++ b/strava-data-puller/tests/test_curated_copy.py
@@ -1,0 +1,93 @@
+"""Tests for curated parquet copy-out (_copy_parquet_to_curated)."""
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location(
+        "strava_pull",
+        Path(__file__).parent.parent / "strava_pull.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # Stub heavy optional deps before loading
+    import types
+
+    for dep in ("duckdb", "requests"):
+        if dep not in sys.modules:
+            sys.modules[dep] = types.ModuleType(dep)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+strava_pull = load_module()
+
+
+class TestCopyParquetToCurated:
+    def test_copies_existing_parquet_files(self, tmp_path):
+        """Existing parquet files in out_dir are copied to curated_dir."""
+        out_dir = tmp_path / "raw"
+        out_dir.mkdir()
+        curated_dir = tmp_path / "curated"
+        curated_dir.mkdir()
+
+        # Create a couple of parquet files
+        (out_dir / "activities.parquet").write_bytes(b"fake-parquet-activities")
+        (out_dir / "athlete.parquet").write_bytes(b"fake-parquet-athlete")
+        # stats.parquet intentionally absent
+
+        strava_pull._copy_parquet_to_curated(out_dir, curated_dir)
+
+        assert (curated_dir / "activities.parquet").read_bytes() == b"fake-parquet-activities"
+        assert (curated_dir / "athlete.parquet").read_bytes() == b"fake-parquet-athlete"
+        assert not (curated_dir / "stats.parquet").exists()
+
+    def test_skips_missing_files_silently(self, tmp_path):
+        """Files absent from out_dir are not created in curated_dir."""
+        out_dir = tmp_path / "raw"
+        out_dir.mkdir()
+        curated_dir = tmp_path / "curated"
+        curated_dir.mkdir()
+        # No parquet files at all
+
+        strava_pull._copy_parquet_to_curated(out_dir, curated_dir)
+
+        assert list(curated_dir.iterdir()) == []
+
+    def test_overwrites_stale_curated_file(self, tmp_path):
+        """An older curated parquet is replaced with the current raw version."""
+        out_dir = tmp_path / "raw"
+        out_dir.mkdir()
+        curated_dir = tmp_path / "curated"
+        curated_dir.mkdir()
+
+        (curated_dir / "activities.parquet").write_bytes(b"old-stale-content")
+        (out_dir / "activities.parquet").write_bytes(b"new-content")
+
+        strava_pull._copy_parquet_to_curated(out_dir, curated_dir)
+
+        assert (curated_dir / "activities.parquet").read_bytes() == b"new-content"
+
+    def test_creates_curated_dir_when_missing(self, tmp_path):
+        """curated_dir is created if it does not already exist."""
+        out_dir = tmp_path / "raw"
+        out_dir.mkdir()
+        curated_dir = tmp_path / "new" / "curated" / "strava"
+        # curated_dir does NOT exist yet
+
+        (out_dir / "activities.parquet").write_bytes(b"data")
+        curated_dir.mkdir(parents=True)  # caller is responsible for mkdir; test helper
+        strava_pull._copy_parquet_to_curated(out_dir, curated_dir)
+
+        assert (curated_dir / "activities.parquet").exists()
+
+    def test_all_curated_filenames_covered(self, tmp_path):
+        """_CURATED_PARQUET_FILES lists all expected output files."""
+        expected = {
+            "activities.parquet",
+            "athlete.parquet",
+            "stats.parquet",
+            "activity_details.parquet",
+            "activity_streams.parquet",
+        }
+        assert set(strava_pull._CURATED_PARQUET_FILES) == expected


### PR DESCRIPTION
## Summary

After `export_parquet()` runs, copy `*.parquet` files to a separate curated directory so `~/datalake.me/curated/strava/` stays in sync with raw.

## Changes

- **`strava_pull.py`**: Add `--curated-dir` CLI flag (default: `DATALAKE_STRAVA_CURATED_ROOT` env var, fallback `~/datalake.me/curated/strava`; pass empty string to disable)
- **`strava_pull.py`**: Add `_copy_parquet_to_curated()` helper using `shutil.copy2`
- **`catalog.yaml`**: Add `curated_root` field for the strava source
- **`tests/test_curated_copy.py`**: 5 tests for the new helper (copies files, skips missing, overwrites stale, etc.)
- **`tests/test_credentials.py`**: Add `curated_dir=""` to the fake `args` SimpleNamespace

## Verification

```
python3 -m pytest strava-data-puller/tests/ -q
# 31 passed
ruff check strava-data-puller/
# All checks passed!
```

Fixes mohit/tools#67